### PR TITLE
Add action for gathering other jobs' statuses

### DIFF
--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       needs_json:
         required: true
-        type: String
+        type: string
 
 jobs:
   mq-status:

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   mq-status:
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-latest
     steps:
       - name: Transform job outcomes
@@ -18,4 +21,5 @@ jobs:
           echo "ALL_SUCCESS=$(echo "${{ inputs.needs_json }}" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >> $GITHUB_ENV
       - name: Check outcomes
         id: result
-        run: "[ $ALL_SUCCESS == true ]"
+        run: |
+          [[ $ALL_SUCCESS == true ]]

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -1,0 +1,21 @@
+name: Report status for merge queue
+# Pass in the ${{toJSON(needs)}} of the caller and report if all of
+# the caller's required jobs were successful or skipped.
+
+on:
+  workflow_call:
+    inputs:
+      needs:
+        required: true
+        type: String
+
+jobs:
+  mq-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Transform job outcomes
+        run: |
+          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >> $GITHUB_ENV
+      - name: Check outcomes
+        id: result
+        run: "[ $ALL_SUCCESS == true ]"

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -16,10 +16,7 @@ jobs:
         shell: bash
     runs-on: ubuntu-latest
     steps:
-      - name: Transform job outcomes
+      - name: Check job outcomes
         run: |
-          echo "ALL_SUCCESS=$(echo "${{ inputs.needs_json }}" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >> $GITHUB_ENV
-      - name: Check outcomes
-        id: result
-        run: |
-          [[ $ALL_SUCCESS == true ]]
+          echo "ALL_SUCCESS=$(echo "${{ inputs.needs_json }}" | jq --exit-status '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')"
+

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -5,7 +5,7 @@ name: Report status for merge queue
 on:
   workflow_call:
     inputs:
-      needs:
+      needs_json:
         required: true
         type: String
 
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Transform job outcomes
         run: |
-          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >> $GITHUB_ENV
+          echo "ALL_SUCCESS=$(echo "${{ inputs.needs_json }}" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >> $GITHUB_ENV
       - name: Check outcomes
         id: result
         run: "[ $ALL_SUCCESS == true ]"


### PR DESCRIPTION
This PR adds an action that can collect and report the status of other jobs, succeeding if all of them either succeeded or were skipped. Intended to be the requirement for a merge queue.